### PR TITLE
Don't require org.jetbrains:annotations to be declared

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,7 @@
               </ignoredUnusedDeclaredDependencies>
               <ignoredUsedUndeclaredDependencies>
                 <dependency>io.mockk:mockk-dsl-jvm</dependency>
+                <dependency>org.jetbrains:annotations</dependency>
                 <dependency>org.jetbrains.kotlin:kotlin-stdlib</dependency>
                 <dependency>org.jetbrains.kotlin:kotlin-test</dependency>
               </ignoredUsedUndeclaredDependencies>


### PR DESCRIPTION
This tends to be Kotlin generated code rather than hand written code.