### PR TITLE
Added Maven Site descriptors

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -13,7 +13,7 @@ gpg --fast-import .travis/codesigning.asc
 
 ./mvnw deploy \
     --settings .travis/settings.xml \
-    -P sign-artifacts,ossrh-deploy \
+    -P attach-site-descriptor,sign-artifacts,ossrh-deploy \
     -DskipTests \
     --batch-mode \
     --show-version

--- a/java-parent/src/site/site.xml
+++ b/java-parent/src/site/site.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="GantSign: java-parent"
+  xmlns="http://maven.apache.org/DECORATION/1.8.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"/>

--- a/kotlin-parent/src/site/site.xml
+++ b/kotlin-parent/src/site/site.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="GantSign: kotlin-parent"
+  xmlns="http://maven.apache.org/DECORATION/1.8.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"/>

--- a/pom.xml
+++ b/pom.xml
@@ -997,6 +997,26 @@
     </profile>
 
     <profile>
+      <id>attach-site-descriptor</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-descriptor</id>
+                <goals>
+                  <goal>attach-descriptor</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>sign-artifacts</id>
       <build>
         <plugins>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="GantSign: common-parent"
+  xmlns="http://maven.apache.org/DECORATION/1.8.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"/>


### PR DESCRIPTION
To fix the following error for downstream projects:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.8.2:site (default-site) on project maven-archetypes: SiteToolException: The site descriptor cannot be resolved from the repository: ArtifactResolutionException: Unable to locate site descriptor: Could not transfer artifact com.github.gantsign.parent:common-parent:xml:site_en:0.9.4
```