### PR TITLE
Fix gh-pages profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,10 +408,10 @@ Deploying the site is a three stage process:
 
 ```bash
 # Build the site
-mvn site -P gh-pages
+mvn site
 
 # Prepare the site for upload
-mvn site:stage -P gh-pages
+mvn site:stage
 
 # Upload the site
 mvn scm-publish:publish-scm -P gh-pages

--- a/pom.xml
+++ b/pom.xml
@@ -1049,7 +1049,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-scm-publish-plugin</artifactId>
             <version>${maven-scm-publish-plugin.version}</version>
-            <extensions>true</extensions>
             <configuration>
               <scmBranch>gh-pages</scmBranch>
               <serverId>github</serverId>


### PR DESCRIPTION
The `maven-scm-publish-plugin` extension mode doesn't work and isn't needed.