### PR TITLE
Added Error Prone checks for Mockito

### DIFF
--- a/java-parent/pom.xml
+++ b/java-parent/pom.xml
@@ -60,6 +60,11 @@
                   <artifactId>plexus-compiler-javac-errorprone</artifactId>
                   <version>${plexus-compiler-javac-errorprone.version}</version>
                 </dependency>
+                <dependency>
+                  <groupId>org.mockito</groupId>
+                  <artifactId>mockito-errorprone</artifactId>
+                  <version>${mockito.version}</version>
+                </dependency>
               </dependencies>
             </plugin>
           </plugins>


### PR DESCRIPTION
Error Prone 2.3.4 extracted the Mockito checks into the Mockito Error Prone sub-project.