### PR TITLE
Add Error Prone checks for Mockito

### DIFF
--- a/java-parent/pom.xml
+++ b/java-parent/pom.xml
@@ -46,6 +46,13 @@
                 <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 <showDeprecation>true</showDeprecation>
                 <showWarnings>true</showWarnings>
+                <annotationProcessorPaths>
+                  <path>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-errorprone</artifactId>
+                    <version>${mockito.version}</version>
+                  </path>
+                </annotationProcessorPaths>
               </configuration>
               <dependencies>
                 <!-- override plexus-compiler-javac-errorprone's dependency on


### PR DESCRIPTION
Error Prone 2.3.4 extracted the Mockito checks into the Mockito Error Prone sub-project.