### PR TITLE
Rename java.version Maven property to java.target.version

### DIFF
--- a/java-parent/pom.xml
+++ b/java-parent/pom.xml
@@ -16,8 +16,8 @@
   <description>Parent for Java projects</description>
 
   <properties>
-    <java.version>11</java.version>
-    <requireJavaVersion>${java.version}</requireJavaVersion>
+    <java.target.version>11</java.target.version>
+    <requireJavaVersion>${java.target.version}</requireJavaVersion>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
     <guava.version>28.2-jre</guava.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <jacoco.file.minimum-coverage-ratio>0.75</jacoco.file.minimum-coverage-ratio>
-    <java.version>1.8</java.version>
+    <java.target.version>1.8</java.target.version>
     <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
     <jib-maven-plugin.version>1.8.0</jib-maven-plugin.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit-jupiter.version>5.6.0</junit-jupiter.version>
     <junit.version>4.13</junit.version>
     <kotlin-logging.version>1.7.8</kotlin-logging.version>
-    <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
+    <kotlin.compiler.jvmTarget>${java.target.version}</kotlin.compiler.jvmTarget>
     <kotlin.version>1.3.61</kotlin.version>
     <ktlint-maven-plugin.version>1.4.0</ktlint-maven-plugin.version>
     <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
@@ -74,7 +74,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <reproducible-build-maven-plugin.version>0.11</reproducible-build-maven-plugin.version>
-    <requireJavaVersion>[${java.version},9)</requireJavaVersion>
+    <requireJavaVersion>[${java.target.version},9)</requireJavaVersion>
     <revision>development-SNAPSHOT</revision>
     <slf4j.version>1.7.30</slf4j.version>
     <sortpom-maven-plugin.version>2.10.0</sortpom-maven-plugin.version>
@@ -810,8 +810,8 @@
         <jdk>[,9)</jdk>
       </activation>
       <properties>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>${java.target.version}</maven.compiler.source>
+        <maven.compiler.target>${java.target.version}</maven.compiler.target>
       </properties>
     </profile>
 
@@ -821,7 +821,7 @@
         <jdk>[9,)</jdk>
       </activation>
       <properties>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven.compiler.release>${java.target.version}</maven.compiler.release>
       </properties>
     </profile>
 


### PR DESCRIPTION
To avoid a conflict with the system property of the same name.