### PR TITLE
Remove sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: xenial
 
 language: java


### PR DESCRIPTION
The key `sudo` has no effect anymore.