### PR TITLE
Drop plexus-compiler-javac-errorprone dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
     <mockito.version>3.3.0</mockito.version>
     <mockk.version>1.9.3</mockk.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-    <plexus-compiler-javac-errorprone.version>2.8.5</plexus-compiler-javac-errorprone.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <reproducible-build-maven-plugin.version>0.11</reproducible-build-maven-plugin.version>
@@ -112,11 +111,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>extra-enforcer-rules</artifactId>
         <version>${extra-enforcer-rules.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-        <version>${plexus-compiler-javac-errorprone.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
`plexus-compiler-javac-errorprone` is no-longer the recommend approach for using ErrorProne.