### PR TITLE
Remove workaround for MDEP-613

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,14 +328,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${maven-dependency-plugin.version}</version>
-          <dependencies>
-            <dependency>
-              <!-- Workaround for MDEP-613-->
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-dependency-analyzer</artifactId>
-              <version>1.11.3</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
`maven-dependency-plugin` version `3.1.2` contains the fix for `MDEP-613`.