### PR TITLE
Simplified build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,19 +27,10 @@ jobs:
       - name: Build with Maven
         run: .github/scripts/build.sh
 
-  build-all:
-    if: ${{ always() }}
-    name: Build (matrix)
-    runs-on: ubuntu-18.04
-    needs: build
-    steps:
-      - name: Check build matrix status
-        run: "[[ '${{ needs.build.result }}' == 'success' ]] || exit 1"
-
   deploy:
     name: Maven deploy
     runs-on: ubuntu-18.04
-    needs: build-all
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The `build-all` job was unnecessary.