### PR TITLE
Downgraded kotlin-logging from 1.12.0 to 1.11.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit-jupiter.version>5.7.0</junit-jupiter.version>
     <junit.version>4.13.1</junit.version>
-    <kotlin-logging.version>1.12.0</kotlin-logging.version>
+    <kotlin-logging.version>1.11.5</kotlin-logging.version>
     <kotlin.compiler.jvmTarget>${java.target.version}</kotlin.compiler.jvmTarget>
     <kotlin.version>1.4.21-2</kotlin.version>
     <ktlint-maven-plugin.version>1.7.0</ktlint-maven-plugin.version>


### PR DESCRIPTION
The POM for 1.12.0 of kotlin-logging is missing its dependencies e.g. (Slf4j).