### PR TITLE
Replace kotlin-logging with kotlin-logging-jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The following dependencies have their version specified for convenience:
 
 * com.google.code.findbugs:jsr305
 * com.google.guava:guava
-* io.github.microutils:kotlin-logging
+* io.github.microutils:kotlin-logging-jvm
 * org.jetbrains:annotations
 * org.jetbrains.kotlin:kotlin-compiler-embeddable
 * org.jetbrains.kotlin:kotlin-reflect

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
       </dependency>
       <dependency>
         <groupId>io.github.microutils</groupId>
-        <artifactId>kotlin-logging</artifactId>
+        <artifactId>kotlin-logging-jvm</artifactId>
         <version>${kotlin-logging.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Artifact ID has changed to support multiplatform.