### PR TITLE
Bump kotlin-maven-plugin-tools from 0.9.17 to 0.9.26

### DIFF
--- a/kotlin-parent/pom.xml
+++ b/kotlin-parent/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
               <groupId>com.github.gantsign.maven.plugin-tools</groupId>
               <artifactId>kotlin-maven-plugin-tools</artifactId>
-              <version>0.9.17</version>
+              <version>0.9.26</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Bumps kotlin-maven-plugin-tools from 0.9.17 to 0.9.26.