### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
   - dependency-name: com.h3xstream.findsecbugs:findsecbugs-plugin
     versions:
     - "> LATEST"
+  - dependency-name: org.apache.maven.plugins:maven-dependency-plugin
+    versions:
+    - 3.2.0


### PR DESCRIPTION
Ignore `org.apache.maven.plugins:maven-dependency-plugin:3.2.0`.