### PR TITLE
Revert "Bump error_prone_core from 2.10.0 to 2.11.0 (#409)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <checkstyle.failsOnError>true</checkstyle.failsOnError>
     <checkstyle.version>10.0</checkstyle.version>
     <docker.image>${project.artifactId}</docker.image>
-    <error-prone.version>2.11.0</error-prone.version>
+    <error-prone.version>2.10.0</error-prone.version>
     <extra-enforcer-rules.version>1.5.1</extra-enforcer-rules.version>
     <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
     <fmt-maven-plugin.version>2.13</fmt-maven-plugin.version>


### PR DESCRIPTION
This reverts commit e02c1b2498cde4032c61723fcd63c872ea329444.