### PR TITLE
Update GantSign Checkstyle config to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <assertj-guava.version>3.4.0</assertj-guava.version>
     <assertj.version>3.22.0</assertj.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <checkstyle.config-location>https://raw.githubusercontent.com/gantsign/checkstyle-config/3.4.0/checkstyle.xml</checkstyle.config-location>
+    <checkstyle.config-location>https://raw.githubusercontent.com/gantsign/checkstyle-config/3.6.0/checkstyle.xml</checkstyle.config-location>
     <checkstyle.failsOnError>true</checkstyle.failsOnError>
     <checkstyle.version>10.0</checkstyle.version>
     <docker.image>${project.artifactId}</docker.image>


### PR DESCRIPTION
For compatibility with Checkstyle 10.0.