### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
   - dependency-name: org.apache.maven.plugins:maven-dependency-plugin
     versions:
     - 3.2.0
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+  assignees:
+  - freemanjp


### PR DESCRIPTION
To keep the actions up to date.