### PR TITLE
Update GantSign Checkstyle config to 3.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <assertj-guava.version>3.5.0</assertj-guava.version>
     <assertj.version>3.23.1</assertj.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
-    <checkstyle.config-location>https://raw.githubusercontent.com/gantsign/checkstyle-config/3.7.0/checkstyle.xml</checkstyle.config-location>
+    <checkstyle.config-location>https://raw.githubusercontent.com/gantsign/checkstyle-config/3.7.1/checkstyle.xml</checkstyle.config-location>
     <checkstyle.failsOnError>true</checkstyle.failsOnError>
     <checkstyle.version>10.3.4</checkstyle.version>
     <docker.image>${project.artifactId}</docker.image>


### PR DESCRIPTION
For compatibility with Checkstyle 10.3.4.